### PR TITLE
Fix deprecated member 'primary'

### DIFF
--- a/lib/src/group_button_item.dart
+++ b/lib/src/group_button_item.dart
@@ -88,8 +88,7 @@ class GroupButtonItem extends StatelessWidget {
       onPressed: onPressed,
       style: ElevatedButton.styleFrom(
         elevation: elevation ?? 0.0,
-        // ignore: deprecated_member_use
-        primary: _getBackgroundColor(theme),
+        backgroundColor: _getBackgroundColor(theme),
         shape: _buildShape(),
         padding: (width != null || height != null) ? EdgeInsets.zero : null,
         alignment: (width != null || height != null) ? alignment : null,


### PR DESCRIPTION
### Fix deprecated member
This member `primary` was deprecated on `ElevatedButton` and will be removed on newer version of Flutter. (already in the master channel)